### PR TITLE
Cleartext domain and password by specific hash

### DIFF
--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -1,6 +1,6 @@
 import base64
 import requests
-from enzoic.exceptions import UnexpectedEnzoicAPIError
+from enzoic.exceptions import UnexpectedEnzoicAPIError, UnsupportedPasswordType
 from enzoic.utilities import hashing
 from enzoic.enums.password_types import PasswordType
 from urllib.parse import urlencode, quote_plus

--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -81,8 +81,10 @@ class Enzoic:
         PasswordType.NTLM
 
         See: https://www.enzoic.com/docs/passwords-api
-        :param password: The full hash of a password you wish to check. Must match the corresponding hash_type
-        parameter
+        :param hashed_pw: The full hash of a password you wish to check. Must match the corresponding hash_type
+        parameter. Only the first 7 characters will be sent.
+        :param hash_type: The int of the respective password hash supplied, possible values are:
+         NTLM, MD5, SHA1, SHA256 (33, 1, 2, 3 respectively)
         :return: True if the password is a known, compromised password and should not be used
         """
         if hash_type == PasswordType.NTLM:
@@ -103,7 +105,7 @@ class Enzoic:
             )
 
         payload = {
-            key: hashed_pw[:8]
+            key: hashed_pw[:7]
         }
 
         response = self._make_rest_call(
@@ -597,7 +599,6 @@ class Enzoic:
         # username needs to be converted to lowercase and url encoded
         query_params = {
             "username": str(username).lower(),
-            "includePasswords": 1,
         }
 
         if include_exposure_details:
@@ -625,7 +626,6 @@ class Enzoic:
         # username needs to be converted to sha256 partial hash and url encoded
         query_params = {
             "partialUsernameHash": hashing.calc_sha256_unsalted_hash(str(username).lower())[:8],
-            "includePasswords": 1,
         }
 
         if include_exposure_details:

--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -74,9 +74,10 @@ class Enzoic:
     def check_hashed_password(self, hashed_pw: str, hash_type: int) -> bool:
         """
         Checks whether the provided password is in the Enzoic database of known, compromised passwords. Pass in the type
-        of password
+        of password hash. Supports NTLM, MD5, SHA1, SHA256 (33, 1, 2, 3 respectively).
         See: https://www.enzoic.com/docs/passwords-api
-        :param password: The plaintext password to be checked, will only be checked against NTLM hashes.
+        :param password: The full hash of a password you wish to check. Must match the corresponding hash_type
+        parameter
         :return: True if the password is a known, compromised password and should not be used
         """
         if hash_type == PasswordType.NTLM:
@@ -635,7 +636,7 @@ class Enzoic:
         else:
             return response.json()
 
-    def get_user_passwords_by_domain(self, domain: str, page_size: int = 100, paging_token: str = None) -> Union[bool, Dict]:
+    def get_user_passwords_by_domain(self, domain: str, page_size: int = None, paging_token: str = None) -> Union[bool, Dict]:
         """
         See: https://api.enzoic.com/v1/cleartext-credentials-by-domain
         :param domain: The domain you wish to receive a list of exposed users and their passwords for.

--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -74,7 +74,12 @@ class Enzoic:
     def check_hashed_password(self, hashed_pw: str, hash_type: int) -> bool:
         """
         Checks whether the provided password is in the Enzoic database of known, compromised passwords. Pass in the type
-        of password hash. Supports NTLM, MD5, SHA1, SHA256 (33, 1, 2, 3 respectively).
+        of password hash. Supports NTLM, MD5, SHA1, SHA256 (33, 1, 2, 3 respectively). You can utilize the PasswordTypes
+        enum for ease of use like so:
+
+        from enzoic.enums.password_types import PasswordType
+        PasswordType.NTLM
+
         See: https://www.enzoic.com/docs/passwords-api
         :param password: The full hash of a password you wish to check. Must match the corresponding hash_type
         parameter

--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -593,6 +593,7 @@ class Enzoic:
             "username": str(username).lower(),
             "includePasswords": 1,
         }
+
         if include_exposure_details:
             query_params["includeExposureDetails"] = int(include_exposure_details)
 
@@ -634,9 +635,29 @@ class Enzoic:
         else:
             return response.json()
 
+    def get_user_passwords_by_domain(self, domain: str, page_size: int = 100, paging_token: str = None) -> Union[bool, Dict]:
+        """
+        See: https://api.enzoic.com/v1/cleartext-credentials-by-domain
+        :param domain: The domain you wish to receive a list of exposed users and their passwords for.
+        :param page_size: The amount of results returned per request, defaults to 100, max is 500.
+        :param paging_token: If there are additional pages of results then use this to get the next page.
+        :return:
+        """
+        query_params = {
+            "domain": str(domain).lower(),
+        }
+        if page_size:
+            query_params["pageSize"] = str(page_size)
+
+        if paging_token:
+            query_params["pagingToken"] = paging_token
+
+        result = urlencode(query_params, quote_via=quote_plus)
 
         response = self._make_rest_call(
-            self.api_base_url + self.ACCOUNTS_API_PATH + f"?{result}", "GET", None)
+            self.api_base_url + f"/cleartext-credentials-by-domain?{result}", "GET", None
+        )
+
         if response.status_code == 404:
             return False
         else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="enzoic",
-    version="1.32",
+    version="2.0",
     author="Enzoic",
     author_email="mike@enzoic.com",
     description="Python Client for Enzoic",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="enzoic",
-    version="2.0",
+    version="1.4",
     author="Enzoic",
     author_email="mike@enzoic.com",
     description="Python Client for Enzoic",

--- a/tests/test_enzoic.py
+++ b/tests/test_enzoic.py
@@ -691,8 +691,8 @@ class TestGetUserPasswordsByPartialHash:
         ]
 
     def test_get_user_password_not_found(self, enzoic):
-        response = enzoic().get_user_passwords_by_partial_hash(username="@@bogus-user@@")
-        assert response is False
+        response = enzoic().get_user_passwords_by_partial_hash(username="!!!!!@@bogus-user@@!!!!!")
+        assert len(response["candidates"]) == 0
 
     def test_account_without_permissions(self, enzoic, enzoic_exceptions):
         with pytest.raises(enzoic_exceptions.UnexpectedEnzoicAPIError) as exc_info:


### PR DESCRIPTION
Add the following function calls to the SDK:

1. get_user_passwords_by_partial_hash() - retrieves a user's passwords by providing a sha256 of the provided username
2. get_user_passwords_by_domain() - retrieves all the usernames and passwords in plaintext for a given domain
3. check_hashed_password() - checks a provided password hash to see if it is compromised, must be a full NTLM, MD5, SHA1, or SHA256 hash.

Unit tests were also added for the above.