### PR TITLE
Add method to return all candidates for a given partial hash.

### DIFF
--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -140,6 +140,11 @@ class Enzoic:
          NTLM, MD5, SHA1, SHA256 (33, 1, 2, 3 respectively)
         :return: A list of potential matches for the first 7 characters of the hash provided
         """
+        if len(hashed_pw) < 7:
+            raise ValueError(
+                "Password hash must be greater than or equal to 7 characters in length."
+            )
+
         if hash_type == PasswordType.NTLM:
             key = "partialNTLM"
         elif hash_type == PasswordType.SHA256_UNSALTED:

--- a/enzoic/enzoic.py
+++ b/enzoic/enzoic.py
@@ -126,6 +126,57 @@ class Enzoic:
         else:
             return False
 
+    def retrieve_list_of_candidates_for_partial_hash(self, hashed_pw: str, hash_type: int) -> list:
+        """
+        Pass in the type of password hash as well as the first 7 characters of that hash. Supports NTLM, MD5, SHA1,
+        SHA256 (33, 1, 2, 3 respectively). You can utilize the PasswordTypes enum for ease of use like so:
+
+        from enzoic.enums.password_types import PasswordType
+        PasswordType.NTLM
+
+        See: https://www.enzoic.com/docs/passwords-api
+        :param hashed_pw: The first 7 characters of the hash type you wish to check.
+        :param hash_type: The int of the respective password hash supplied, possible values are:
+         NTLM, MD5, SHA1, SHA256 (33, 1, 2, 3 respectively)
+        :return: A list of potential matches for the first 7 characters of the hash provided
+        """
+        if hash_type == PasswordType.NTLM:
+            key = "partialNTLM"
+        elif hash_type == PasswordType.SHA256_UNSALTED:
+            key = "partialSHA256"
+        elif hash_type == PasswordType.MD5_UNSALTED:
+            key = "partialMD5"
+        elif hash_type == PasswordType.SHA1_UNSALTED:
+            key = "partialSHA1"
+        else:
+            raise UnsupportedPasswordType(
+                "Unsupported hash type provided. The following values for 'password_type' are supported:"
+                f"\nNTLM: {PasswordType.NTLM}"
+                f"\nMD5: {PasswordType.MD5_UNSALTED}"
+                f"\nSHA1: {PasswordType.SHA1_UNSALTED}"
+                f"\nSHA256: {PasswordType.SHA256_UNSALTED}"
+            )
+
+        payload = {
+            key: hashed_pw[:7]
+        }
+
+        response = self._make_rest_call(
+            self.api_base_url + self.PASSWORDS_API_PATH, "POST", body=payload
+        )
+
+        if response.status_code != 404:
+            if hash_type == PasswordType.NTLM:
+                return [candidate["ntlm"] for candidate in response.json()["candidates"]]
+            elif hash_type == PasswordType.MD5_UNSALTED:
+                return [candidate["md5"] for candidate in response.json()["candidates"]]
+            elif hash_type == PasswordType.SHA1_UNSALTED:
+                return [candidate["sha1"] for candidate in response.json()["candidates"]]
+            elif hash_type == PasswordType.SHA256_UNSALTED:
+                return [candidate["sha256"] for candidate in response.json()["candidates"]]
+        else:
+            return []
+
     def check_password_ex(self, password: str) -> Tuple[bool, bool, None, int]:
         """
         Checks whether the provided password is in the Enzoic database of known, compromised passwords and returns the

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="enzoic",
-    version="1.40",
+    version="1.50",
     author="Enzoic",
     author_email="mike@enzoic.com",
     description="Python Client for Enzoic",

--- a/tests/test_enzoic.py
+++ b/tests/test_enzoic.py
@@ -199,7 +199,7 @@ class TestCheckPassword:
         for candidate in candidates:
             assert candidate.startswith(sha1_hash)
 
-    def test_unsupported_partial_hash_type_provided(self, enzoic, password_types, enzoic_exceptions):
+    def test_get_candidates_unsupported_partial_hash_type_provided(self, enzoic, password_types, enzoic_exceptions):
         ntlm_hash = "8846f7e"
         with pytest.raises(enzoic_exceptions.UnsupportedPasswordType) as exc_info:
             enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.VBulletinPost3_8_5)
@@ -209,15 +209,11 @@ class TestCheckPassword:
             assert password_types.SHA256_UNSALTED in str(exc_info.value)
             assert password_types.MD5_UNSALTED in str(exc_info.value)
 
-    def test_uncompromised_partial_hash_no_results(self, enzoic, password_types):
-        ntlm_hash = "z000000"
-        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.NTLM)
-        assert len(candidates) == 0
-
     def test_partial_hash_too_short(self, enzoic, password_types):
-        ntlm_hash = "000000"
-        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.NTLM)
-        assert len(candidates) == 0
+        with pytest.raises(ValueError) as exc_info:
+            ntlm_hash = "000000"
+            enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.NTLM)
+            assert "Password hash must be greater than or equal to 7 characters in length." in exc_info.value
 
 
 class TestGetUserPasswords:

--- a/tests/test_enzoic.py
+++ b/tests/test_enzoic.py
@@ -171,6 +171,54 @@ class TestCheckPassword:
         ntlm_hash = "6708d6fd35e9fbcda86be9703a20af8c6f595a2f"
         assert enzoic().check_hashed_password(hashed_pw=ntlm_hash, hash_type=password_types.NTLM) is False
 
+    def test_get_candidates_by_partial_ntlm_hash(self, enzoic, password_types):
+        ntlm_hash = "8846f7e"
+        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.NTLM)
+        assert len(candidates) > 0
+        for candidate in candidates:
+            assert candidate.startswith(ntlm_hash)
+
+    def test_get_candidates_by_partial_md5_hash(self, enzoic, password_types):
+        md5_hash = "5f4dcc3"
+        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=md5_hash, hash_type=password_types.MD5_UNSALTED)
+        assert len(candidates) > 0
+        for candidate in candidates:
+            assert candidate.startswith(md5_hash)
+
+    def test_get_candidates_by_partial_sha256_hash(self, enzoic, password_types):
+        sha256_hash = "5e88489"
+        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=sha256_hash, hash_type=password_types.SHA256_UNSALTED)
+        assert len(candidates) > 0
+        for candidate in candidates:
+            assert candidate.startswith(sha256_hash)
+
+    def test_get_candidates_by_partial_sha1_hash(self, enzoic, password_types):
+        sha1_hash = "5baa61e"
+        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=sha1_hash, hash_type=password_types.SHA256_UNSALTED)
+        assert len(candidates) > 0
+        for candidate in candidates:
+            assert candidate.startswith(sha1_hash)
+
+    def test_unsupported_partial_hash_type_provided(self, enzoic, password_types, enzoic_exceptions):
+        ntlm_hash = "8846f7e"
+        with pytest.raises(enzoic_exceptions.UnsupportedPasswordType) as exc_info:
+            enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.VBulletinPost3_8_5)
+            assert "Unsupported hash type provided." in str(exc_info.value)
+            assert password_types.NTLM in str(exc_info.value)
+            assert password_types.SHA1_UNSALTED in str(exc_info.value)
+            assert password_types.SHA256_UNSALTED in str(exc_info.value)
+            assert password_types.MD5_UNSALTED in str(exc_info.value)
+
+    def test_uncompromised_partial_hash_no_results(self, enzoic, password_types):
+        ntlm_hash = "z000000"
+        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.NTLM)
+        assert len(candidates) == 0
+
+    def test_partial_hash_too_short(self, enzoic, password_types):
+        ntlm_hash = "000000"
+        candidates = enzoic().retrieve_list_of_candidates_for_partial_hash(hashed_pw=ntlm_hash, hash_type=password_types.NTLM)
+        assert len(candidates) == 0
+
 
 class TestGetUserPasswords:
     def test_get_user_password(self, enzoic):


### PR DESCRIPTION
Pass in a partial hash (7 characters or more) of an NTLM, SHA1, SHA256, or MD5 hash along with the type of the provided hash to retrieve a list of candidates.